### PR TITLE
K8s: Fix cc-processor:k8s, re-pull k8s images before deployment

### DIFF
--- a/k8s/ns1.yaml
+++ b/k8s/ns1.yaml
@@ -29,11 +29,15 @@ spec:
       containers:
       - name: cc-broker-vnf
         image: sonatanfv/vnf-cc-broker:k8s
+        imagePullPolicy: Always
         ports:
         - containerPort: 1883
       - name: cc-processor-vnf
         image: sonatanfv/vnf-cc-processor:k8s
+        imagePullPolicy: Always
       - name: eae-vnf
         image: sonatanfv/vnf-eae:k8s
+        imagePullPolicy: Always
         ports:
         - containerPort: 3000
+        

--- a/vnfs/cc-cloudconnector-docker/containers/cdu_processor/Dockerfile.vimemu
+++ b/vnfs/cc-cloudconnector-docker/containers/cdu_processor/Dockerfile.vimemu
@@ -45,8 +45,8 @@ RUN apt-get install -y mosquitto-clients
 RUN pip3 install azure-iothub-device-client
 RUN pip3 install paho-mqtt
 
-ADD start.sh start.sh
-RUN chmod +x start.sh
+ADD start.vimemu.sh start.vimemu.sh
+RUN chmod +x start.vimemu.sh
 
 # add VNF CC app
 ADD CC_VNF CC_VNF
@@ -60,7 +60,7 @@ ENV MQTT_BROKER_PORT 1883
 ENV AZURE_SECRET_FILE /CC_VNF/azure_connection_string.secret
 
 # set entry point for emulator (configuration script)
-ENV VIM_EMU_CMD "./start.sh"
+ENV VIM_EMU_CMD "./start.vimemu.sh"
 
 # this has to be /bin/bash for the emulator
 CMD /bin/bash

--- a/vnfs/cc-cloudconnector-docker/containers/cdu_processor/start.vimemu.sh
+++ b/vnfs/cc-cloudconnector-docker/containers/cdu_processor/start.vimemu.sh
@@ -28,4 +28,4 @@
 sleep 2  # give the broker some time to get up (yes ugly, but avoids race conditions)
 echo "CC-CDU02 (processor): Starting Azure Cloud Connector ... (logs: /var/cc.log)"
 cd /CC_VNF
-python3 CC_VNF.py > /var/cc.log 2>&1
+python3 CC_VNF.py > /var/cc.log 2>&1 &


### PR DESCRIPTION
* Updated cc-processor for k8s to be blocking (separate start.vimemu.sh for vimemu)
* `imagePullPolicy: always` for all k8s containers to ensure always the latest version is pulled from DockerHub - even though we always use the same tag `:k8s`