### PR TITLE
Split k8s descriptors per CDU

### DIFF
--- a/k8s/ns1.yaml
+++ b/k8s/ns1.yaml
@@ -6,14 +6,17 @@ metadata:
     app: ns1
     pilot: sm
 spec:
+  selector:
+    app: ns1
+  # for single-node testing with microk8s; switch to "LoadBalancer" for production
+  type: NodePort
   ports:
     - name: mqtt
       port: 1883
+    # cluster-internal access via port 3000, external via port 30000
     - name: grafana
       port: 3000
-  selector:
-    app: ns1
-  type: LoadBalancer
+      nodePort: 30000
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/k8s/ns1/cc-broker.yaml
+++ b/k8s/ns1/cc-broker.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ns1-cc-broker-service
+  # for easy reference later on
+  labels:
+    pilot: sm
+    ns: ns1
+    cnf: cc
+    cdu: cc-broker
+spec:
+  # to which deployment does this service belong?
+  selector:
+    cdu: cc-broker
+  type: NodePort
+  ports:
+    - name: mqtt
+      port: 1883
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ns1-cc-broker-deployment
+  labels:
+    pilot: sm
+    ns: ns1
+    cnf: cc
+    cdu: cc-broker
+spec:
+  selector:
+    # must match the labels of the template
+    matchLabels:
+      pilot: sm
+      ns: ns1
+      cnf: cc
+      cdu: cc-broker
+  # the pod(s) to deploy = 1 CDU
+  template:
+    metadata:
+      labels:
+        pilot: sm
+        ns: ns1
+        cnf: cc
+        cdu: cc-broker
+    spec:
+      containers:
+      - name: vnf-cc-broker
+        image: sonatanfv/vnf-cc-broker:k8s
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 1883

--- a/k8s/ns1/cc-processor.yaml
+++ b/k8s/ns1/cc-processor.yaml
@@ -1,0 +1,48 @@
+# apiVersion: v1
+# kind: Service
+# metadata:
+  # name: ns1-cc-processor-service
+  # # for easy reference later on
+  # labels:
+    # pilot: sm
+    # ns: ns1
+    # cnf: cc
+    # cdu: cc-processor
+# spec:
+  # # to which deployment does this service belong?
+  # selector:
+    # cdu: cc-processor
+  # type: NodePort
+  # ports:
+    # - 
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ns1-cc-processor-deployment
+  labels:
+    pilot: sm
+    ns: ns1
+    cnf: cc
+    cdu: cc-processor
+spec:
+  selector:
+    # must match the labels of the template
+    matchLabels:
+      pilot: sm
+      ns: ns1
+      cnf: cc
+      cdu: cc-processor
+  # the pod(s) to deploy = 1 CDU
+  template:
+    metadata:
+      labels:
+        pilot: sm
+        ns: ns1
+        cnf: cc
+        cdu: cc-processor
+    spec:
+      containers:
+      - name: vnf-cc-processor
+        image: sonatanfv/vnf-cc-processor:k8s
+        imagePullPolicy: Always

--- a/k8s/ns1/eae.yaml
+++ b/k8s/ns1/eae.yaml
@@ -1,18 +1,19 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: ns1
+  name: ns1-eae-service
+  # for easy reference later on
   labels:
-    app: ns1
     pilot: sm
+    ns: ns1
+    cnf: eae
+    cdu: eae
 spec:
+  # to which deployment does this service belong?
   selector:
-    app: ns1
-  # for single-node testing with microk8s; switch to "LoadBalancer" for production
+    cdu: eae
   type: NodePort
   ports:
-    - name: mqtt
-      port: 1883
     # cluster-internal access via port 3000, external via port 30000
     - name: grafana
       port: 3000
@@ -21,31 +22,32 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sm-ns1-deployment
+  name: ns1-eae-deployment
   labels:
-    app: ns1
     pilot: sm
+    ns: ns1
+    cnf: eae
+    cdu: eae
 spec:
   selector:
+    # must match the labels of the template
     matchLabels:
-      app: ns1
+      pilot: sm
+      ns: ns1
+      cnf: eae
+      cdu: eae
+  # the pod(s) to deploy = 1 CDU
   template:
     metadata:
       labels:
-        app: ns1
+        pilot: sm
+        ns: ns1
+        cnf: eae
+        cdu: eae
     spec:
       containers:
-      - name: vnf-cc-broker
-        image: sonatanfv/vnf-cc-broker:k8s
-        imagePullPolicy: Always
-        ports:
-        - containerPort: 1883
-      - name: vnf-cc-processor
-        image: sonatanfv/vnf-cc-processor:k8s
-        imagePullPolicy: Always
       - name: vnf-eae
         image: sonatanfv/vnf-eae:k8s
         imagePullPolicy: Always
         ports:
         - containerPort: 3000
-        

--- a/k8s/ns2/dt.yaml
+++ b/k8s/ns2/dt.yaml
@@ -1,10 +1,13 @@
 # apiVersion: v1
 # kind: Service
 # metadata:
-  # name: ns2
+  # name: ns2-dt-service
+  # # for easy reference later on
   # labels:
-    # app: ns2
     # pilot: sm
+    # ns: ns2
+    # cnf: dt
+    # cdu: dt
 # spec:
   # ports:
     # - name: dt
@@ -20,31 +23,34 @@
     # - name: samba138udp
       # protocol: UDP
       # port: 138
-  # selector:
-    # app: ns2
-  # type: LoadBalancer
-# ---
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sm-ns2-deployment
+  name: ns2-dt-deployment
   labels:
-    app: ns2
     pilot: sm
+    ns: ns2
+    cnf: dt
+    cdu: dt
 spec:
   selector:
+    # must match the labels of the template
     matchLabels:
-      app: ns2
+      pilot: sm
+      ns: ns2
+      cnf: dt
+      cdu: dt
+  # the pod(s) to deploy = 1 CDU
   template:
     metadata:
       labels:
-        app: ns2
+        pilot: sm
+        ns: ns2
+        cnf: dt
+        cdu: dt
     spec:
       containers:
       - name: vnf-dt
         image: sonatanfv/vnf-dt:k8s
         imagePullPolicy: Always
-      - name: vnf-mdc
-        image: sonatanfv/vnf-mdc:k8s
-        imagePullPolicy: Always
-        

--- a/k8s/ns2/mdc.yaml
+++ b/k8s/ns2/mdc.yaml
@@ -1,0 +1,56 @@
+# apiVersion: v1
+# kind: Service
+# metadata:
+  # name: ns2-mdc-service
+  # # for easy reference later on
+  # labels:
+    # pilot: sm
+    # ns: ns2
+    # cnf: mdc
+    # cdu: mdc
+# spec:
+  # ports:
+    # - name: mdc
+      # port: 15001
+    # - name: samba139
+      # port: 139
+    # - name: samba445
+      # port: 445
+    # # can't mix TCP and UDP ports in a single LB service
+    # - name: samba137udp
+      # protocol: UDP
+      # port: 137
+    # - name: samba138udp
+      # protocol: UDP
+      # port: 138
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ns2-mdc-deployment
+  labels:
+    pilot: sm
+    ns: ns2
+    cnf: mdc
+    cdu: mdc
+spec:
+  selector:
+    # must match the labels of the template
+    matchLabels:
+      pilot: sm
+      ns: ns2
+      cnf: mdc
+      cdu: mdc
+  # the pod(s) to deploy = 1 CDU
+  template:
+    metadata:
+      labels:
+        pilot: sm
+        ns: ns2
+        cnf: mdc
+        cdu: mdc
+    spec:
+      containers:
+      - name: vnf-mdc
+        image: sonatanfv/vnf-mdc:k8s
+        imagePullPolicy: Always


### PR DESCRIPTION
Ensure separate pods for each CDU by splitting the descriptors into separate deployments and services per CDU. As described here: https://stackoverflow.com/a/43220561/2745116

Refers to #72 