### PR TITLE
trying to fix cc processor: use env var to disable cloud connection b…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vnfs/cc-cloudconnector-emulator/containers/cdu_processor/CC_VNF/azure_connection_string.secret
+vnfs/cc-cloudconnector-emulator/containers/cdu_processor/CC_VNF/keys.json
 *.secret
 deploy_rdev.sh
 *.tgo

--- a/vnfs/cc-cloudconnector-docker/containers/cdu_processor/Dockerfile
+++ b/vnfs/cc-cloudconnector-docker/containers/cdu_processor/Dockerfile
@@ -58,7 +58,7 @@ ADD CC_VNF CC_VNF
 
 ENV IFLOCAL data
 
-# only for dummy MQTT generator not for MDC APP
-ENV AZURE_SECRET_FILE /CC_VNF/azure_connection_string.secret
+# by default, don't try to connect to Azure; Use "True" to enable
+ENV ENABLE_CLOUD_CONNECTION False
 
 CMD ./start.sh

--- a/vnfs/cc-cloudconnector-docker/containers/cdu_processor/Dockerfile.vimemu
+++ b/vnfs/cc-cloudconnector-docker/containers/cdu_processor/Dockerfile.vimemu
@@ -60,6 +60,9 @@ ENV MQTT_BROKER_PORT 1883
 # only for dummy MQTT generator not for MDC APP
 ENV AZURE_SECRET_FILE /CC_VNF/azure_connection_string.secret
 
+# by default, don't try to connect to Azure; Use "True" to enable
+ENV ENABLE_CLOUD_CONNECTION False
+
 # set entry point for emulator (configuration script)
 ENV VIM_EMU_CMD "./start.vimemu.sh"
 


### PR DESCRIPTION
…y default

By default, disable connection to Azure, which caused the errors due to the empty `keys.json`.

Use env var `ENABLE_CLOUD_CONNECTION` and set to `True` to enable.

Closes #89 