### PR TITLE
added fixed nodeports for mdc's samba share

### DIFF
--- a/k8s/ns2/mdc.yaml
+++ b/k8s/ns2/mdc.yaml
@@ -16,19 +16,25 @@ spec:
     cnf: mdc
     cdu: mdc
   type: NodePort
+  # this only works when setting a custom --service-node-port-range 
+  # minikube start --extra-config=apiserver.service-node-port-range=137-445
   ports:
     - name: samba139
       protocol: TCP
       port: 139
+      nodePort: 139
     - name: samba445
       protocol: TCP
       port: 445
+      nodePort: 445
     - name: samba137
       protocol: UDP
       port: 137
+      nodePort: 137
     - name: samba138
       protocol: UDP
       port: 138
+      nodePort: 138
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
Requires changing the default port ranges for NodePort services when starting minikube or microk8s.

Maybe better to go with a LoadBalancer service in the future.

See #72 