### PR TITLE
aligned ids k8s descriptor: no namespace, similar labels and name

### DIFF
--- a/k8s/ns2/ids.yml
+++ b/k8s/ns2/ids.yml
@@ -1,14 +1,39 @@
+#  Copyright (c) 2018 5GTANGO, Paderborn University
+# ALL RIGHTS RESERVED.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Neither the name of the SONATA-NFV, 5GTANGO, Paderborn University
+# nor the names of its contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# This work has also been performed in the framework of the 5GTANGO project,
+# funded by the European Commission under Grant number 761493 through
+# the Horizon 2020 and 5G-PPP programmes. The authors would like to
+# acknowledge the contributions of their colleagues of the SONATA
+# partner consortium (www.5gtango.eu).
+
+
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: sm
-  name: ns2s
+  name: ns2-ids-deployment
   labels:
-    #pilot: sm
-    #ns: ns3
-    #cnf: ids
-    name: ns2s
+    pilot: sm
+    ns: ns2
+    cnf: ids
 spec:
   volumes:
   - name: suricata-logs


### PR DESCRIPTION
* Couldn't start with namespace + should not rely on that since we probably also won't have this in the SP right?
* Aligned labels and name with other k8s descriptors for consistency
* Also added license header (feel free to adjust)
