### PR TITLE
Updated Tango descriptors for NS2 with IDS

### DIFF
--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/nsd/mdc-selk.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/nsd/mdc-selk.yml
@@ -1,9 +1,38 @@
+#  Copyright (c) 2018 5GTANGO
+# ALL RIGHTS RESERVED.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Neither the name of the SONATA-NFV, 5GTANGO
+# nor the names of its contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# This work has also been performed in the framework of the 5GTANGO project,
+# funded by the European Commission under Grant number 761493 through
+# the Horizon 2020 and 5G-PPP programmes. The authors would like to
+# acknowledge the contributions of their colleagues of the SONATA
+# partner consortium (www.5gtango.eu).
+
+
+---
 descriptor_schema: https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/service-descriptor/nsd-schema.yml
 vendor: eu.5gtango
-name: tng-smpilot-mdc-eids
+name: tng-smpilot-ns2-eids
 version: '0.1'
 author: sm-pilot@5gtango.eu
 description: 'a CNF for MDC with SELK (sidecar) enhanced security barrier'
+
 network_functions:
 - vnf_id: vnf1
   vnf_vendor: eu.5gtango
@@ -21,95 +50,58 @@ network_functions:
   vnf_vendor: eu.5gtango
   vnf_name: k-vnf4
   vnf_version: '0.1'
+  
+# external CPs of the NS. only need to define what needs to be accessible from the outside
 connection_points:
-- id: cp0
-  interface: ipv4
-  type: external
 - id: smb139
   interface: ipv4
-  type: internal
+  type: external
 - id: smb445
   interface: ipv4
-  type: internal
-- id: cp1a
+  type: external
+- id: logstash5044
   interface: ipv4
-  type: internal
-- id: cp1s
+  type: external
+- id: flask5000
   interface: ipv4
-  type: internal
-- id: cp1f
+  type: external
+- id: kibana5601
   interface: ipv4
-  type: internal
-- id: cp2l
+  type: external
+- id: elastic9200
   interface: ipv4
-  type: internal
-- id: cp3
-  interface: ipv4
-  type: internal
-- id: cp4
-  interface: ipv4
-  type: internal
+  type: external
+
+# connects the extral CPs of the NS with the CPs of the VNFs
 virtual_links:
-- id: vl01139
-  connectivity_type: E-Line
+- id: smb139link
+  connectivity_type: E-LAN
   connection_points_reference:
-  - cp0
-  - vnf1:smb139
-- id: vl01445
-  connectivity_type: E-Line
+    - smb139
+    - vnf1:smb139
+- id: smb445link
+  connectivity_type: E-LAN
   connection_points_reference:
-  - cp0
-  - vnf1:smb445
-- id: vl01aea
-  connectivity_type: E-Line
+    - smb445
+    - vnf1:smb445
+- id: logstash5044link
+  connectivity_type: E-LAN
   connection_points_reference:
-  - cp0
-  - vnf1:cp1a
-- id: vl01s
-  connectivity_type: E-Line
+    - logstash5044
+    - vnf2:logstash5044
+- id: flask5000link
+  connectivity_type: E-LAN
   connection_points_reference:
-  - cp0
-  - vnf1:cp1s
-- id: vl12
-  connectivity_type: E-Line
+    - flask5000
+    - vnf2:flask5000
+- id: elastic9200link
+  connectivity_type: E-LAN
   connection_points_reference:
-  - vnf1:cp1f
-  - vnf2:cp2l
-- id: vl23
-  connectivity_type: E-Line
+    - elastic9200
+    - vnf3:elastic9200
+- id: kibana5601link
+  connectivity_type: E-LAN
   connection_points_reference:
-  - vnf2:cp2l
-  - vnf3:cp3
-- id: vl34
-  connectivity_type: E-Line
-  connection_points_reference:
-  - vnf3:cp3
-  - vnf4:cp4
-#forwarding_graphs:
-#- fg_id: fg01
-#  number_of_endpoints: 1
-#  number_of_virtual_links: 4
-#  constituent_virtual_links:
-#  - vl01
-#  - vl12
-#  - vl23
-#  - vl34
-#  constituent_vnfs:
-#  - vnf1
-#  - vnf2
-#  - vnf3
-#  - vnf4
-#  network_forwarding_paths:
-#  - fp_id: fg01:fp01
-#    policy: none
-#    connection_points:
-#    - connection_point_ref: cp0
-#      position: 1
-#    - connection_point_ref: vnf1:cp1
-#      position: 2
-#    - connection_point_ref: vnf2:cp2
-#      position: 3
-#    - connection_point_ref: vnf3:cp3
-#      position: 4
-#    - connection_point_ref: vnf4:cp4
-#      position: 5
+    - kibana5601
+    - vnf4:kibana5601
+      

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/nsd/mdc-selk.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/nsd/mdc-selk.yml
@@ -65,7 +65,7 @@ connection_points:
 - id: flask5000
   interface: ipv4
   type: external
-- id: kibana5601
+- id: kibana
   interface: ipv4
   type: external
 - id: elastic9200
@@ -99,9 +99,9 @@ virtual_links:
   connection_points_reference:
     - elastic9200
     - vnf3:elastic9200
-- id: kibana5601link
+- id: kibanalink
   connectivity_type: E-LAN
   connection_points_reference:
-    - kibana5601
-    - vnf4:kibana5601
+    - kibana
+    - vnf4:kibana
       

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/e.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/e.yml
@@ -1,46 +1,56 @@
+#  Copyright (c) 2018 5GTANGO
+# ALL RIGHTS RESERVED.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Neither the name of the SONATA-NFV, 5GTANGO
+# nor the names of its contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# This work has also been performed in the framework of the 5GTANGO project,
+# funded by the European Commission under Grant number 761493 through
+# the Horizon 2020 and 5G-PPP programmes. The authors would like to
+# acknowledge the contributions of their colleagues of the SONATA
+# partner consortium (www.5gtango.eu).
+
+
 descriptor_schema: https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/function-descriptor/vnfd-schema.yml
 vendor: eu.5gtango
 name: e-vnf3
 version: '0.1'
 author: sm-pilot@5gtango.eu
 description: 'a CNF based on official Elasticsearch image'
+
+# loosely corresponds to the "containers" section in a k8s deployment
 cloudnative_deployment_units:
 - id: cdu01
-  image: sonatanfv/vnf-ids-elasticsearch
-  resource_requirements:
-    cpu:
-      vcpus: 2
-    memory:
-      size: 1024
-      size_unit: MB
-    storage:
-      size: 20
-      size_unit: GB
+  image: sonatanfv/vnf-ids-elasticsearch:latest
   connection_points:
-  - id: cp3
-    interface: ipv4
-    type: internal
+  - id: elastic9200
+    port: 9200
+    
+# corresponds to the k8s service layer: connection to the outside world  
 connection_points:
-- id: cp2l
+- id: elastic9200
   interface: ipv4
-  type: internal
-- id: cp3
-  interface: ipv4
-  type: internal
-- id: cp4
-  interface: ipv4
-  type: internal
+  type: serviceendpoint
   port: 9200
+  
+# CNFs only use E-Tree links to map external ports/cp to internal ports/cp
 virtual_links:
-- id: vl23
-  connectivity_type: E-Line
+- id: elastic9200link
+  connectivity_type: E-Tree
   connection_points_reference:
-  - cp2l
-  - cp3
-  dhcp: true
-- id: vl34
-  connectivity_type: E-Line
-  connection_points_reference:
-  - cp3
-  - cp4
-  dhcp: true
+    - elastic9200
+    - cdu01:elastic9200

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/k.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/k.yml
@@ -1,38 +1,56 @@
+#  Copyright (c) 2018 5GTANGO
+# ALL RIGHTS RESERVED.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Neither the name of the SONATA-NFV, 5GTANGO
+# nor the names of its contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# This work has also been performed in the framework of the 5GTANGO project,
+# funded by the European Commission under Grant number 761493 through
+# the Horizon 2020 and 5G-PPP programmes. The authors would like to
+# acknowledge the contributions of their colleagues of the SONATA
+# partner consortium (www.5gtango.eu).
+
+
 descriptor_schema: https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/function-descriptor/vnfd-schema.yml
 vendor: eu.5gtango
 name: k-vnf4
 version: '0.1'
 author: sm-pilot@5gtango.eu
 description: 'a CNF based on official Kibana image'
+
+# loosely corresponds to the "containers" section in a k8s deployment
 cloudnative_deployment_units:
 - id: cdu01
-  image: sonatanfv/vnf-ids-kibana
-  resource_requirements:
-    cpu:
-      vcpus: 2
-    memory:
-      size: 1024
-      size_unit: MB
-    storage:
-      size: 20
-      size_unit: GB
+  image: sonatanfv/vnf-ids-kibana:latest
   connection_points:
-  - id: cp4
-    interface: ipv4
-    type: internal
+  - id: kibana
+    port: 5601
+    
+# corresponds to the k8s service layer: connection to the outside world 
 connection_points:
-- id: cp3
+- id: kibana5601
   interface: ipv4
-  type: internal
-  port: 9200
-- id: cp4
-  interface: ipv4
-  type: internal
+  type: serviceendpoint
   port: 5601
+  
+# CNFs only use E-Tree links to map external ports/cp to internal ports/cp
 virtual_links:
-- id: vl34
-  connectivity_type: E-Line
+- id: kibana5601link
+  connectivity_type: E-Tree
   connection_points_reference:
-  - cp3
-  - cp4
-  dhcp: true
+    - kibana5601
+    - cdu01:kibana5601

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/k.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/k.yml
@@ -42,15 +42,15 @@ cloudnative_deployment_units:
     
 # corresponds to the k8s service layer: connection to the outside world 
 connection_points:
-- id: kibana5601
+- id: kibana
   interface: ipv4
   type: serviceendpoint
   port: 5601
   
 # CNFs only use E-Tree links to map external ports/cp to internal ports/cp
 virtual_links:
-- id: kibana5601link
+- id: kibana-link
   connectivity_type: E-Tree
   connection_points_reference:
-    - kibana5601
-    - cdu01:kibana5601
+    - kibana
+    - cdu01:kibana

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/lh.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/lh.yml
@@ -1,75 +1,70 @@
+#  Copyright (c) 2018 5GTANGO
+# ALL RIGHTS RESERVED.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Neither the name of the SONATA-NFV, 5GTANGO
+# nor the names of its contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# This work has also been performed in the framework of the 5GTANGO project,
+# funded by the European Commission under Grant number 761493 through
+# the Horizon 2020 and 5G-PPP programmes. The authors would like to
+# acknowledge the contributions of their colleagues of the SONATA
+# partner consortium (www.5gtango.eu).
+
+
 descriptor_schema: https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/function-descriptor/vnfd-schema.yml
 vendor: eu.5gtango
 name: lh-vnf2
 version: '0.1'
 author: sm-pilot@5gtango.eu
 description: 'a CNF based on official Logstash image from Elastic and Flask lightweight HTTP server'
+
+# loosely corresponds to the "containers" section in a k8s deployment
 cloudnative_deployment_units:
 - id: cdu01
-  image: sonatanfv/vnf-ids-logstash
-  resource_requirements:
-    cpu:
-      vcpus: 2
-    memory:
-      size: 1024
-      size_unit: MB
-    storage:
-      size: 20
-      size_unit: GB
+  image: sonatanfv/vnf-ids-logstash:latest
   connection_points:
-  - id: cp2l
-    interface: ipv4
-    type: internal
-    port: 5400
+  - id: logstash5044
+    port: 5044
 - id: cdu02
-  image: sonatanfv/vnf-ids-flask
-  resource_requirements:
-    cpu:
-      vcpus: 1
-    memory:
-      size: 512
-      size_unit: MB
-    storage:
-      size: 10
-      size_unit: GB
+  image: sonatanfv/vnf-ids-http:latest
   connection_points:
-  - id: cp2h
-    interface: ipv4
-    type: internal
+  - id: flask5000
     port: 5000
+    
+# corresponds to the k8s service layer: connection to the outside world
 connection_points:
-- id: cp0
-  interface: ipv4
-  type: external
-- id: cp1f
-  interface: ipv4
-  type: internal
-- id: cp2l
-  interface: ipv4
-  type: internal
-- id: cp2h
-  interface: ipv4
-  type: internal
-- id: cp3
-  interface: ipv4
-  type: internal
-  port: 9200
+  - id: logstash5044
+    interface: ipv4
+    type: serviceendpoint
+    port: 5044
+  - id: flask5000
+    interface: ipv4
+    type: serviceendpoint
+    port: 5000
+  
+# CNFs only use E-Tree links to map external ports/cp to internal ports/cp
 virtual_links:
-- id: vl02
-  connectivity_type: E-Line
+- id: logstash5044link
+  connectivity_type: E-Tree
   connection_points_reference:
-  - cp0
-  - cp2h
-  dhcp: true
-- id: vl12
-  connectivity_type: E-Line
+    - logstash5044
+    - cdu01:logstash5044
+- id: flask5000link
+  connectivity_type: E-Tree
   connection_points_reference:
-  - cp1f
-  - cp2l
-  dhcp: true
-- id: vl23
-  connectivity_type: E-Line
-  connection_points_reference:
-  - cp2l
-  - cp3
-  dhcp: true
+    - flask5000
+    - cdu02:flask5000

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/msf.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/msf.yml
@@ -37,16 +37,16 @@ cloudnative_deployment_units:
 - id: cdu01
   image: 'sonatanfv/vnf-mdc:latest'
   connection_points:
-  - id: smb139
-    port: 139
-  - id: smb445
-    port: 445
-    parameters:
-      env:
-        # TODO: this should point to the k8s service layer of the CC
-        # the SP should add an env variable that contains this k8s service name
-        MQTT_BROKER_HOST: ns1-cc-service
-        MQTT_BROKER_PORT: 1883
+    - id: smb139
+      port: 139
+    - id: smb445
+      port: 445
+  parameters:
+    env:
+      # TODO: this should point to the k8s service layer of the CC
+      # the SP should add an env variable that contains this k8s service name
+      MQTT_BROKER_HOST: ns1-cc-service
+      MQTT_BROKER_PORT: 1883
 - id: cdu02
   image: sonatanfv/vnf-ids-suricata:latest
   connection_points: []

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/msf.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/msf.yml
@@ -52,9 +52,7 @@ cloudnative_deployment_units:
   connection_points: []
 - id: cdu03
   image: sonatanfv/vnf-ids-filebeat:latest
-  connection_points:
-  - id: filebeat5044
-    port: 5044
+  connection_points: []
     
 # corresponds to the k8s service layer: connection of CNFs to the outside world
 # no need to worry about connections inside the CNF. these go via localhost and don't need to be defined here

--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/msf.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/msf.yml
@@ -1,9 +1,38 @@
+#  Copyright (c) 2018 5GTANGO
+# ALL RIGHTS RESERVED.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Neither the name of the SONATA-NFV, 5GTANGO
+# nor the names of its contributors may be used to endorse or promote
+# products derived from this software without specific prior written
+# permission.
+#
+# This work has also been performed in the framework of the 5GTANGO project,
+# funded by the European Commission under Grant number 761493 through
+# the Horizon 2020 and 5G-PPP programmes. The authors would like to
+# acknowledge the contributions of their colleagues of the SONATA
+# partner consortium (www.5gtango.eu).
+
+
 descriptor_schema: https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/function-descriptor/vnfd-schema.yml
 vendor: eu.5gtango
 name: msf-vnf1
 version: '0.1'
 author: sm-pilot@5gtango.eu
 description: 'a CNF with three VDUs: MDC + Suricata + Filebeat'
+
+# loosely corresponds to the "containers" section in a k8s deployment
 cloudnative_deployment_units:
 - id: cdu01
   image: 'sonatanfv/vnf-mdc:latest'
@@ -12,94 +41,44 @@ cloudnative_deployment_units:
     port: 139
   - id: smb445
     port: 445
-  - id: cp1a
-  parameters:
-    env:
-      # TODO: this should point to the k8s service layer of the CC
-      # the SP should add an env variable that contains this k8s service name
-      MQTT_BROKER_HOST: ns1-cc-service
-      MQTT_BROKER_PORT: 1883
+    parameters:
+      env:
+        # TODO: this should point to the k8s service layer of the CC
+        # the SP should add an env variable that contains this k8s service name
+        MQTT_BROKER_HOST: ns1-cc-service
+        MQTT_BROKER_PORT: 1883
 - id: cdu02
-  image: sonatanfv/vnf-ids-suricata
-  resource_requirements:
-    cpu:
-      vcpus: 1
-    memory:
-      size: 512
-      size_unit: MB
-    storage:
-      size: 10
-      size_unit: GB
-  connection_points:
-  - id: cp1s
-    interface: ipv4
-    type: internal
+  image: sonatanfv/vnf-ids-suricata:latest
+  connection_points: []
 - id: cdu03
-  image: sonatanfv/vnf-ids-filebeat
-  resource_requirements:
-    cpu:
-      vcpus: 1
-    memory:
-      size: 512
-      size_unit: MB
-    storage:
-      size: 10
-      size_unit: GB
+  image: sonatanfv/vnf-ids-filebeat:latest
   connection_points:
-  - id: cp1f
-    interface: ipv4
-    type: internal
+  - id: filebeat5044
     port: 5044
+    
+# corresponds to the k8s service layer: connection of CNFs to the outside world
+# no need to worry about connections inside the CNF. these go via localhost and don't need to be defined here
 connection_points:
-- id: cp0
-  interface: ipv4
-  type: external
 - id: smb139
   interface: ipv4
-  type: internal
+  type: serviceendpoint
+  port: 139
 - id: smb445
   interface: ipv4
-  type: internal
-- id: cp1a
-  interface: ipv4
-  type: internal
-- id: cp1s
-  interface: ipv4
-  type: internal
-- id: cp1f
-  interface: ipv4
-  type: internal
-- id: cp2l
-  interface: ipv4
-  type: internal
+  type: serviceendpoint
+  port: 445
+
+
+# CNFs only use E-Tree links to map external ports/cp to internal ports/cp
+# no need to worry about connections inside the CNF. these go via localhost and don't need to be defined here
 virtual_links:
-- id: vl01aea
-  connectivity_type: E-Line
+- id: samba139link
+  connectivity_type: E-Tree
   connection_points_reference:
-  - cp1a
-  - cp0
-  dhcp: true
-- id: vl01139
-  connectivity_type: E-Line
+    - smb139
+    - cdu01:smb139
+- id: samba445link
+  connectivity_type: E-Tree
   connection_points_reference:
-  - smb139
-  - cp0
-  dhcp: true
-- id: vl01445
-  connectivity_type: E-Line
-  connection_points_reference:
-  - smb445
-  - cp0
-  dhcp: true
-- id: vl01s
-  connectivity_type: E-Line
-  connection_points_reference:
-  - cp1s
-  - cp0
-  dhcp: true
-- id: vl12
-  connectivity_type: E-Line
-  connection_points_reference:
-  - cp1f
-  - cp2l
-  dhcp: true
+    - smb445
+    - cdu01:smb445


### PR DESCRIPTION
Quite major changes to adjust the way how connection points, vlinks, etc are defined to what's needed for CNFs when deploying on the SP.