### PR TITLE
fix typo on ES and LS: elasticsearch.hosts: ["http://elasticsearch:92…

### DIFF
--- a/vnfs/ids-selk/k/kibana.yml
+++ b/vnfs/ids-selk/k/kibana.yml
@@ -5,6 +5,6 @@ server.port: 5601 # Default
 server.name: kibana
 server.host: "0.0.0.0"
 #elasticsearch.url: http://elasticsearch:9200
-elasticsearch.hosts: [http://elasticsearch:9200]
+elasticsearch.hosts: ["http://elasticsearch:9200"]
 xpack.monitoring.ui.container.elasticsearch.enabled: true
 

--- a/vnfs/ids-selk/l/logstash.yml
+++ b/vnfs/ids-selk/l/logstash.yml
@@ -1,4 +1,4 @@
 http.host: "0.0.0.0"
 xpack.monitoring.enabled: true
-xpack.monitoring.elasticsearch.url: http://elasticsearch:9200
+xpack.monitoring.elasticsearch.hosts: ["http://elasticsearch:9200"]
 


### PR DESCRIPTION
…00"]