### PR TITLE
Instantiation params

### DIFF
--- a/sdk-projects/inst_params_ns2.yml
+++ b/sdk-projects/inst_params_ns2.yml
@@ -1,0 +1,1 @@
+MQTT_BROKER_HOST: <ns1_cc_floating_ip>

--- a/sdk-projects/inst_params_ns2.yml
+++ b/sdk-projects/inst_params_ns2.yml
@@ -1,1 +1,6 @@
+# for MQTT connection to NS1 (get IP after instantiating NS1)
 MQTT_BROKER_HOST: <ns1_cc_floating_ip>
+
+# for configuration of IDS: this is the only allowed user and hostname to connect to the MDC without an alarm
+SMB_USER_NAME: localadmin
+SMB_CLIENT_NAME: k8s-master


### PR DESCRIPTION
Added yaml with instantiation params for NS2 that can be passed on instantiation with `tng-cli`. For

* connection to NS1
* and configuration of IDS. See https://github.com/sonata-nfv/tng-industrial-pilot/wiki/IDS-deployment#instantiation-1