### PR TITLE
fix FSM; logging improvements in SSM

### DIFF
--- a/ssms/ns2-ssm/ns2/ns2.py
+++ b/ssms/ns2-ssm/ns2/ns2.py
@@ -146,19 +146,20 @@ class ns2SSM(smbase):
         The configure event comes from the policy manager or via the control server from the FMP.
         It indicates an intrusion and should trigger a reconfiguration event sent to the MDC FSM.
         """
-        LOG.debug("NS2 SSM: configuration event triggered with content: {}".format(content))
+        LOG.debug("NS2 SSM: Starting configuration event")
         
         response = {'status': 'COMPLETED', 'vnf': []}
         
         # get IDs of all VNF instances
         for vnf in content['functions']:
+            vnf_name = vnf['vnfr']['name']
             vnf_dict = {
-                'id': vnf['vnfr']['id'], 
+                'id': vnf['vnfr']['id'],
+                'name': vnf_name,
                 'configure': {'trigger': False}
             }
             
             # trigger reconfig only for MDC VNF
-            vnf_name = vnf['vnfr']['name']
             if vnf_name == 'msf-vnf1':
                 vnf_dict['configure']['trigger'] = True
                 vnf_dict['configure']['payload'] = {'message': 'IDS Alert 1'}
@@ -167,7 +168,7 @@ class ns2SSM(smbase):
                 
             LOG.debug("Added VNF {} to response with {}".format(vnf_name, vnf_dict))
 
-        LOG.info("NS2 SSM response: {}".format(response))
+        LOG.info("NS2 SSM configure event complete")
         
         return response
 


### PR DESCRIPTION
Avoid key error due to different expected format of `content` passed to FSM