### PR TITLE
Feature/back to ind pilot probe

### DIFF
--- a/vnv-tests/probes/mqtt/Makefile
+++ b/vnv-tests/probes/mqtt/Makefile
@@ -1,7 +1,7 @@
 build:
-	docker build -t easyglobalmarket/mqtt-probe .
+	docker build -t easyglobalmarket/mqtt-probe:v1.0 .
 push:
-	docker push easyglobalmarket/mqtt-probe	
+	docker push easyglobalmarket/mqtt-probe:v1.0	
 run:
 	docker run  -e "IP=$(ip)" -e "PORT=$(port)" -e "CLIENTS=$(clients)" -e "COUNT=$(count)" -e "SIZE=$(size)" -e "USERNAME=$(username)" -e "PASSWORD=$(password)" --name docker-mqtt-probe --net=egm easyglobalmarket/mqtt-probe
 stop:

--- a/vnv-tests/probes/mqtt/entrypoint.sh
+++ b/vnv-tests/probes/mqtt/entrypoint.sh
@@ -13,15 +13,9 @@ echo "port = $PORT"
 echo "packet size = $SIZE"
 echo "messages per client = $COUNT"
 echo "clients = $CLIENTS"
-echo "rounds = $ROUNDS"
-echo "qos = $QOS"
 
 echo "******* mqttprobe: executing benchmark *******"
 
-for i in $( eval echo {1..$ROUNDS} )
-do
-    echo "Executing round $i"
-    mqtt-benchmark --broker tcp://$IP:$PORT --count $(( COUNT * i )) --size $(( SIZE * i )) --clients $(( CLIENTS * i )) --qos $QOS --format json --username $USERNAME --password $PASSWORD > $RESULTS_FILE
-done
+mqtt-benchmark --broker tcp://$IP:$PORT --count $COUNT --size $SIZE --clients $CLIENTS --qos 2 --format json --username $USERNAME --password $PASSWORD > $RESULTS_FILE
 
 echo "output redirect to: $RESULTS_FILE"

--- a/vnv-tests/test-packages/TSTINDP/Definitions/test-descriptor.yml
+++ b/vnv-tests/test-packages/TSTINDP/Definitions/test-descriptor.yml
@@ -4,7 +4,7 @@ description: "Performance test for mqtt broker"
 descriptor_schema: https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/test-descriptor/testdescriptor-schema.yml
 name: "test-industrial-pilot-ns1"
 vendor: "eu.5gtango.egm"
-version: '0.8'
+version: '1.0'
 
 service_platforms:
   - "SONATA"
@@ -25,7 +25,7 @@ phases:
       probes:
       - id: mqttprobe
         description: "A service initial configuration container"
-        image: "easyglobalmarket/mqtt-probe:latest"
+        image: "easyglobalmarket/mqtt-probe:v1.0"
         name: mqttprobe
         parameters:
         - key: IP

--- a/vnv-tests/test-packages/TSTINDP/project.yml
+++ b/vnv-tests/test-packages/TSTINDP/project.yml
@@ -3,7 +3,7 @@ version: '0.5'
 package:
   vendor: eu.5gtango
   name: industrial-pilot-test-egm
-  version: '0.9'
+  version: '1.0'
   maintainer: Aureliano Sinatra, EGM
   description: This is a 5GTANGO test package for mqtt Benchmarking
 files:


### PR DESCRIPTION
mqtt test probe has now two versions :

osm-v1.0
v1.0

The first one scale up
The second one not

Osm mqtt stress test will use mqtt-probe:osm-v1.0
Industrial Pilot mqtt stress test will use mqtt-probe:v1.0