### PR TITLE
incremented lhc version number to 0.9 in policy

### DIFF
--- a/policies/industrial-pilot-Security-Policy.json
+++ b/policies/industrial-pilot-Security-Policy.json
@@ -2,7 +2,7 @@
 	"descriptor_schema": "https://raw.githubusercontent.com/sonata-nfv/tng-schema/master/policy-descriptor/policy-schema.yml",
 	"name": "industrial-pilot-Security-Policy1",
 	"vendor": "eu.5gtango",
-	"version": "0.7",
+	"version": "0.8",
 	"network_service": {
 		"vendor": "eu.5gtango",
 		"name": "tng-smpilot-ns2-eids",
@@ -44,7 +44,7 @@
 			"target": {
 				"name": "lhc-vnf2",
 				"vendor": "eu.5gtango",
-				"version": "0.8"
+				"version": "0.9"
 			}
 		}]
 	}]


### PR DESCRIPTION
Noticed that policy didn't work. Maybe because the version number of the Logstash CNF didn't match the descriptor?

Fixed here.