### PR TITLE
removed mano-set env vars

### DIFF
--- a/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/k.yml
+++ b/sdk-projects/tng-smpilot-ns2-k8s-eids/vnfd/k.yml
@@ -50,8 +50,6 @@ cloudnative_deployment_units:
     unit: "MB"
   parameters:
     env:
-      e_vnf3_eu_5gtango_0_9_elastic9200_ip: localhost # 'localhost' just as default, this will be overridden by the SP
-      e_vnf3_eu_5gtango_0_9_elastic9200_port: 9200
       VERSION: "0.9"
  
 # corresponds to the k8s service layer: connection to the outside world 


### PR DESCRIPTION
Hopefully fixes https://github.com/sonata-nfv/tng-industrial-pilot/issues/340

According to Thomas, vars set by the MANO should not be declared in the VNFD